### PR TITLE
Add posibility for selector to be ObjectId object

### DIFF
--- a/lib/mongo/lib/idSelector.js
+++ b/lib/mongo/lib/idSelector.js
@@ -8,10 +8,8 @@ export function isIdSelector(selector) {
 export function getIdsFromSelector(selector) {
   if (typeof selector == 'string') {
     return [selector]
-  } else if (typeof selector._id === 'string') {
+  } else if (typeof selector._id === 'string' || typeof selector._id._str === 'string') {
     return [selector._id];
-  } else if (typeof selector._id._str === 'string') {
-    return [selector._id._str];
   } else {
     return _.isObject(selector._id) && selector._id.$in ? selector._id.$in : null;
   }

--- a/lib/mongo/lib/idSelector.js
+++ b/lib/mongo/lib/idSelector.js
@@ -6,6 +6,13 @@ export function isIdSelector(selector) {
 }
 
 export function getIdsFromSelector(selector) {
-  if (typeof selector == 'string') return [selector]
-  return typeof selector._id === 'string' ? [selector._id] : _.isObject(selector._id) && selector._id.$in ? selector._id.$in : null
+  if (typeof selector == 'string') {
+    return [selector]
+  } else if (typeof selector._id === 'string') {
+    return [selector._id];
+  } else if (typeof selector._id._str === 'string') {
+    return [selector._id._str];
+  } else {
+    return _.isObject(selector._id) && selector._id.$in ? selector._id.$in : null;
+  }
 }


### PR DESCRIPTION
This fixed fetchInCacheFirst no ids error for me when isIdSelector() returned true, but getIdsFromSelector returned null. I guess this change is harmless and should not have any side effects.