### PR TITLE
Fix Meteor's Mongo.Cursor.map() Params

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -22,8 +22,18 @@ const Strategy = {
   LIMIT_SORT: 'LS'
 }
 
+const VentConstants = {
+  ID: 'i',
+  EVENT_VARIABLE: 'e',
+  PREFIX: '__vent',
+  getPrefix(id, name) {
+      return `${id}.${name}`;
+  }
+}
+
 export {
   Events,
   Strategy,
-  RedisPipe
+  RedisPipe,
+  VentConstants
 }

--- a/lib/mongo/extendMongoCollection.js
+++ b/lib/mongo/extendMongoCollection.js
@@ -214,7 +214,7 @@ export default () => {
           var overrideCB
           if (options.skipSave) overrideCB = (cb, _this) => {
             if (_this) cb.bind(_this)
-            return (doc) => {
+            return (doc, index, __this) => {
               // cache ALWAYS overrules
               if (this.hasCache(doc._id)) {
                 doc = this.getCache(doc._id)
@@ -223,12 +223,12 @@ export default () => {
                   catch(e) { }
                 }
               }
-              return cb(doc)
+              return cb(doc, index, __this)
             }
           }
           else overrideCB = (cb, _this) => {
             if (_this) cb.bind(_this)
-            return (doc) => {
+            return (doc, index, __this) => {
               // cache ALWAYS overrules
               if (this.hasCache(doc._id)) doc = this.getCache(doc._id)
               // any doc we touch, we have to save it
@@ -240,7 +240,7 @@ export default () => {
                 try { doc = projector(doc) }
                 catch(e) { }
               }
-              return cb(doc)
+              return cb(doc, index, __this)
             }
           }
           // we have to unfortunately override all the methods, as we don't know which the user will call

--- a/lib/vent/Vent.js
+++ b/lib/vent/Vent.js
@@ -1,0 +1,127 @@
+import {getRedisListener, getRedisPusher} from '../redis/getRedisClient';
+import {VentConstants} from '../constants';
+import {Meteor} from 'meteor/meteor';
+import {Random} from 'meteor/random';
+import Config from '../config';
+
+// TODO:
+// Unify listening of events with RedisSubscriptionManager
+
+export default class Vent {
+    /**
+     * @param name
+     * @param fn
+     * @returns {*|any|Observable}
+     */
+    static publish(name, fn) {
+        // check initialization
+        if (!Config.isInitialized) {
+            throw new Meteor.Error('not-initialized', 'RedisOplog is not initialized at the time of defining this publish. Make sure you initialize it before');
+        }
+
+        if (_.isObject(name)) {
+            _.each(name, (fn, _name) => {
+                Vent.publish(_name, fn);
+            });
+
+            return;
+        }
+
+        // validate if everything is in order
+        Vent._validateArguments(name, fn);
+
+        // create the publication properly
+        return Vent._createPublishEndPoint(name, fn);
+    }
+
+    /**
+     * @param {string} channel
+     * @param {object} object
+     */
+    static emit(channel, object) {
+        const {pubSubManager} = Config;
+
+        pubSubManager.publish(channel, object);
+    }
+
+    /**
+     * Creates the publish endpoint
+     *
+     * @param name
+     * @param fn
+     * @returns {*|any|Observable}
+     * @private
+     */
+    static _createPublishEndPoint(name, fn) {
+        return Meteor.publish(name, function (collectionId, ...args) {
+            Vent._extendPublishContext(this, name, collectionId);
+
+            try {
+                fn.call(this, ...args);
+            } catch (e) {
+                // we do this because the errors in here are silenced
+                console.error(e);
+                throw e;
+            }
+
+            this.ready();
+        });
+    }
+
+    /**
+     * @param context
+     * @param name
+     * @param collectionId
+     * @private
+     */
+    static _extendPublishContext(context, name, collectionId) {
+        const channelHandlers = [];
+        const { pubSubManager } = Config;
+
+        Object.assign(context, {
+            on(channel, redisEventHandler) {
+                // create the handler for this channel
+                const handler = function(message) {
+                    const data = redisEventHandler.call(context, message);
+
+                    if (data) {
+                        context._session.send({
+                            msg: 'changed',
+                            [VentConstants.PREFIX]: '1',
+                            id: VentConstants.getPrefix(collectionId, name),
+                            [VentConstants.EVENT_VARIABLE]: data
+                        });
+                    }
+                };
+                channelHandlers.push({ channel, handler });
+                pubSubManager.subscribe(channel, handler);
+            },
+        });
+
+        context.onStop(function () {
+            channelHandlers.forEach(({ channel, handler }) => {
+              pubSubManager.unsubscribe(channel, handler);
+            });
+        });
+    }
+
+    /**
+     * @param name
+     * @param fn
+     * @private
+     */
+    static _validateArguments(name, fn) {
+        // validate arguments
+        if (!_.isString(name)) {
+            if (!_.isObject(name)) {
+                throw new Meteor.Error('invalid-definition', 'Argument is invalid')
+            }
+
+        } else {
+            if (!_.isFunction(fn)) {
+                throw new Meteor.Error('invalid-definition', 'The second argument needs to be a function')
+            }
+        }
+    }
+}
+

--- a/lib/vent/VentClient.js
+++ b/lib/vent/VentClient.js
@@ -1,0 +1,107 @@
+import {VentConstants} from '../constants';
+import {Random} from 'meteor/random';
+import {DDPCommon} from 'meteor/ddp-common';
+
+/**
+ * Handles vents inside Meteor
+ */
+export default class VentClient {
+    constructor() {
+        this.store = {};
+        this.listen(Meteor.connection);
+    }
+
+    subscribe(name, ...args) {
+        const subscription = new VentClientSubscription(this, name);
+        this.add(subscription);
+
+        return subscription.subscribe(...args);
+    }
+
+    listen(ddpConnection) {
+        ddpConnection._stream.on('message', (raw_msg) => {
+            // avoid parsing unnecessary ddp events
+            const search = `{"msg":"changed","${VentConstants.PREFIX}":"1`;
+            if (raw_msg.substr(0, search.length) !== search) {
+                return;
+            }
+
+            const msg = DDPCommon.parseDDP(raw_msg);
+            const subscription = this.store[msg.id];
+            if (subscription) {
+                subscription.handle(msg[VentConstants.EVENT_VARIABLE]);
+            }
+        });
+    }
+
+    /**
+     * {VentClientSubscription}
+     * @param subscription
+     */
+    add(subscription) {
+        this.store[subscription.id] = subscription;
+    }
+
+    /**
+     * @param {VentClientSubscription} subscription
+     */
+    remove(subscription) {
+        delete this.store[subscription.id];
+    }
+}
+
+/**
+ * Handles Vent subscription
+ */
+class VentClientSubscription {
+    constructor(client, name) {
+        this.client = client;
+        this._name = name;
+        this._id = Random.id();
+    }
+
+    get id() {
+        return VentConstants.getPrefix(this._id, this._name);
+    }
+
+    /**
+     * Subscribes to Meteor
+     *
+     * @param args
+     * @returns {*}
+     */
+    subscribe(...args) {
+        const self = this;
+
+        const handler = Meteor.subscribe(this._name, this._id, ...args);
+
+        const oldStop = handler.stop;
+        Object.assign(handler, {
+            listen(eventHandler) {
+                if (!_.isFunction(eventHandler)) {
+                    throw new Meteor.Error('invalid-argument', 'You should pass a function to listen()');
+                }
+
+                self._eventHandler = eventHandler;
+            },
+            stop() {
+                self.client.remove(self);
+
+                return oldStop.call(handler);
+            }
+        });
+
+        return handler;
+    }
+
+    /**
+     * Watches the incomming events
+     */
+    handle(event) {
+        if (this._eventHandler) {
+            this._eventHandler(event);
+        } else {
+
+        }
+    }
+}

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line
 Package.describe({
   name: 'zegenie:redis-oplog',
-  version: '2.0.15',
+  version: '2.0.16',
   // Brief, one-line summary of the package.
   summary: "Replacement for Meteor's MongoDB oplog implementation",
   // URL to the Git repository containing the source code for this package.
@@ -33,6 +33,7 @@ Package.onUse(function(api) {
   ])
 
   api.mainModule('redis-oplog.js', 'server');
+  api.mainModule('redis-oplog.client.js', 'client');
 })
 
 // eslint-disable-next-line

--- a/redis-oplog.client.js
+++ b/redis-oplog.client.js
@@ -1,0 +1,5 @@
+import VentClient from './lib/vent/VentClient';
+
+const Vent = new VentClient();
+
+export { Vent };

--- a/redis-oplog.js
+++ b/redis-oplog.js
@@ -8,6 +8,7 @@ import { getRedisListener, getRedisPusher } from './lib/redis/getRedisClient'
 import ObservableCollection from './lib/cache/observableCollection'
 import { addToWatch, removeFromWatch } from './lib/redis/watchManager'
 import { dispatchUpdate, dispatchInsert, dispatchRemove } from './lib/redis/customPublish'
+import Vent from './lib/vent/Vent'
 
 const RedisOplog = {
   init
@@ -25,6 +26,7 @@ export {
   RedisPipe,
   Config,
   Events,
+  Vent,
   getRedisListener,
   getRedisPusher,
   addToWatch,


### PR DESCRIPTION
This corrects the callback signatures fixing the use of Meteor's Mongo.Cursor#map(callback, [thisArg]) function. Before `index` would be undefined.